### PR TITLE
Change github workflows to only run for tagged versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,7 @@
 name: 'CI'
 on:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,14 @@ name: 'CI'
 on:
   push:
     tags:
-      - 'v.*'
+      - 'v*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,16 @@ name: Upload Python Package
 on:
   release:
     types: [created]
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,16 +6,6 @@ name: Upload Python Package
 on:
   release:
     types: [created]
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
-  pull_request:
-    branches:
-      - main
-    tags:
-      - 'v*'
 
 jobs:
   deploy:

--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -6,6 +6,8 @@ name: Upload Python Package
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch
+  release:
+    types: [created]
   push:
     branches:
       - main

--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -9,9 +9,13 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
+    tags:
+      - 'v*'
 
 jobs:
   deploy:

--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -8,16 +8,6 @@ on:
   # but only for the main branch
   release:
     types: [created]
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
-  pull_request:
-    branches:
-      - main
-    tags:
-      - 'v*'
 
 jobs:
   deploy:


### PR DESCRIPTION
Pipeline has been triggered for all PRs into main and the build and publish workflow should only be triggered for tagged PRs (so only for releases).