### PR TITLE
Feature/context manager

### DIFF
--- a/aries_cloudcontroller/aries_controller_base.py
+++ b/aries_cloudcontroller/aries_controller_base.py
@@ -1,7 +1,7 @@
 from aiohttp import (
     ClientSession,
 )
-from abc import ABC
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from pubsub import pub
 
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class AriesAgentControllerBase(ABC):
+class AriesAgentControllerBase(AbstractAsyncContextManager):
     """The Aries Agent Controller class
 
     This class allows you to interact with Aries by exposing the aca-py API.
@@ -97,7 +97,7 @@ class AriesAgentControllerBase(ABC):
 
         self.revocations = RevocationController(self.admin_url, self.client_session)
 
-    def __enter__(self):
+    async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc_value, exc_traceback):

--- a/aries_cloudcontroller/aries_controller_base.py
+++ b/aries_cloudcontroller/aries_controller_base.py
@@ -97,6 +97,12 @@ class AriesAgentControllerBase(ABC):
 
         self.revocations = RevocationController(self.admin_url, self.client_session)
 
+    def __enter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, exc_traceback):
+        await self.terminate()
+
     def init_webhook_server(self):
         raise NotImplementedError
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def parse_requirements(filename):
 if __name__ == "__main__":
     setup(
         name=PACKAGE_NAME,
-        version="0.2.6",
+        version="0.2.7",
         description="A simple python package for controlling an aries agent through the admin-api interface",
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/tests/test_aries_controller_base.py
+++ b/tests/test_aries_controller_base.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import unittest
 from aiohttp import (
     ClientSession,
 )

--- a/tests/test_aries_controller_base.py
+++ b/tests/test_aries_controller_base.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import unittest
 from aiohttp import (
     ClientSession,
 )
@@ -211,3 +212,19 @@ class TestAriesAgentControllerBase:
         with pytest.raises(AttributeError):
             assert ac.webhook_server is None
         await ac.terminate()
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, caplog):
+        caplog.set_level(logging.INFO)
+        api_key = "123456789"
+
+        async with AriesAgentControllerBase(admin_url="", api_key=api_key) as ac:
+            assert ac.client_session
+            assert ac.api_key == api_key
+            assert ac.headers == {"X-API-Key": api_key}
+            ac.remove_api_key()
+
+        assert ac.headers == {}
+        assert ac.api_key is None
+        assert ac.client_session.headers == {}
+        assert "Client Session closed." in caplog.text


### PR DESCRIPTION
## Description
Add `__aenter__` and `__aexit__` dundar emthods to base class so the controller can be used by as by/as context manager like:

```
async with AriesAgentController(*args) as ac:
    ac.do_stuff
```

and the terminate() method will be called when leaving the context. This allows for using the controller without having to explicitly call terminate (as cvurrently done in the notebooks). Note, this does not break current usage, it merely extends to have async context manager capability.  

## Affected Dependencies
None

## How has this been tested?
- Not yet
