### PR TITLE
Add params to query subwallets for multitenancy

### DIFF
--- a/aries_cloudcontroller/controllers/multitenant.py
+++ b/aries_cloudcontroller/controllers/multitenant.py
@@ -48,4 +48,4 @@ class MultitenancyController(BaseController):
         if wallet_name:
             params["wallet_name"] = wallet_name
 
-        return await self.admin_GET(f"{self.base_url}/wallets")
+        return await self.admin_GET(f"{self.base_url}/wallets", params=params)


### PR DESCRIPTION
Background:
The wallet_name was not passed as a param. Qerying a wallet by name
would therefore return all wallets from the ledger and not the specific
wallet.