### PR TITLE
Fix response schemas that have custom types in ACA-Py

### DIFF
--- a/aries_cloudcontroller/model/attach_decorator_data.py
+++ b/aries_cloudcontroller/model/attach_decorator_data.py
@@ -25,7 +25,9 @@ class AttachDecoratorData(BaseModel):
     """
 
     base64: Optional[str] = None
-    json_: Optional[Dict[str, Any]] = Field(None, alias="json")
+    json_: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = Field(
+        None, alias="json"
+    )
     jws: Optional[AttachDecoratorDataJWS] = None
     links: Optional[List[str]] = None
     sha256: Optional[str] = None

--- a/aries_cloudcontroller/model/credential.py
+++ b/aries_cloudcontroller/model/credential.py
@@ -27,7 +27,7 @@ class Credential(BaseModel):
         proof: The proof of the credential [Optional].
     """
 
-    context: List[Union[str,Dict]] = Field(..., alias="@context")
+    context: List[Union[str, Dict]] = Field(..., alias="@context")
     credential_subject: Dict[str, Any] = Field(..., alias="credentialSubject")
     issuance_date: str = Field(..., alias="issuanceDate")
     issuer: Union[str, Dict[str, Any]]

--- a/aries_cloudcontroller/model/credential.py
+++ b/aries_cloudcontroller/model/credential.py
@@ -30,7 +30,7 @@ class Credential(BaseModel):
     context: List[Union[str,Dict]] = Field(..., alias="@context")
     credential_subject: Dict[str, Any] = Field(..., alias="credentialSubject")
     issuance_date: str = Field(..., alias="issuanceDate")
-    issuer: Union[str,Dict[str, Any]]
+    issuer: Union[str, Dict[str, Any]]
     type: List[str]
     expiration_date: Optional[str] = Field(None, alias="expirationDate")
     id: Optional[str] = None

--- a/aries_cloudcontroller/model/credential.py
+++ b/aries_cloudcontroller/model/credential.py
@@ -30,7 +30,7 @@ class Credential(BaseModel):
     context: List[Dict] = Field(..., alias="@context")
     credential_subject: Dict[str, Any] = Field(..., alias="credentialSubject")
     issuance_date: str = Field(..., alias="issuanceDate")
-    issuer: Dict[str, Any]
+    issuer: Union[str,Dict[str, Any]]
     type: List[str]
     expiration_date: Optional[str] = Field(None, alias="expirationDate")
     id: Optional[str] = None

--- a/aries_cloudcontroller/model/credential.py
+++ b/aries_cloudcontroller/model/credential.py
@@ -27,7 +27,7 @@ class Credential(BaseModel):
         proof: The proof of the credential [Optional].
     """
 
-    context: List[Dict] = Field(..., alias="@context")
+    context: List[Union[str,Dict]] = Field(..., alias="@context")
     credential_subject: Dict[str, Any] = Field(..., alias="credentialSubject")
     issuance_date: str = Field(..., alias="issuanceDate")
     issuer: Union[str,Dict[str, Any]]

--- a/aries_cloudcontroller/model/filter.py
+++ b/aries_cloudcontroller/model/filter.py
@@ -30,15 +30,19 @@ class Filter(BaseModel):
         type: Type [Optional].
     """
 
-    const: Optional[Dict[str, Any]] = None
-    enum: Optional[List[Dict]] = None
-    exclusive_maximum: Optional[Dict[str, Any]] = Field(None, alias="exclusiveMaximum")
-    exclusive_minimum: Optional[Dict[str, Any]] = Field(None, alias="exclusiveMinimum")
+    const: Optional[Union[str, int, float]] = None
+    enum: Optional[List[Union[str, int, float]]] = None
+    exclusive_maximum: Optional[Union[str, int, float]] = Field(
+        None, alias="exclusiveMaximum"
+    )
+    exclusive_minimum: Optional[Union[str, int, float]] = Field(
+        None, alias="exclusiveMinimum"
+    )
     format: Optional[str] = None
     max_length: Optional[int] = Field(None, alias="maxLength")
-    maximum: Optional[Dict[str, Any]] = None
+    maximum: Optional[Union[str, int, float]] = None
     min_length: Optional[int] = Field(None, alias="minLength")
-    minimum: Optional[Dict[str, Any]] = None
+    minimum: Optional[Union[str, int, float]] = None
     not_: Optional[bool] = Field(None, alias="not")
     pattern: Optional[str] = None
     type: Optional[str] = None

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def parse_requirements(filename: str):
 if __name__ == "__main__":
     setup(
         name=PACKAGE_NAME,
-        version="0.9.0",
+        version="0.9.1-beta0",
         description="A simple python package for controlling an aries agent through the admin-api interface",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
In ACA-Py, they define custom Marshmallow types, such as:
```py
class StrOrNumberField(Field):
    """String or Number field for Marshmallow."""
```

This does not translate correctly in the autogenerated swagger spec; it is indicated to be an object, which is generically translated as a Dict.

This patch updates all request schemas with the custom types as intended in ACA-Py.