### PR TITLE
:wrench: adjust Upload Python Package workflow

### DIFF
--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -4,11 +4,7 @@
 name: Upload Python Package
 
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  push:
-    branches:
-      - main
+  # Trigger the workflow only for pull requests for the main branch
   pull_request:
     branches:
       - main


### PR DESCRIPTION
only publish test packages on pull request, and not on push to main.

This is because the job will _always_ fail on push to main, as the test package will already exist -- the same version tag would have been uploaded during the in-progress pull request.

Official packages are anyway released manually, so not needed in workflow.