### PR TITLE
:construction_worker: set `validate_assignment` config back to True

### DIFF
--- a/aries_cloudcontroller/util/pydantic_model_config.py
+++ b/aries_cloudcontroller/util/pydantic_model_config.py
@@ -3,5 +3,5 @@ from pydantic import ConfigDict
 DEFAULT_PYDANTIC_MODEL_CONFIG: ConfigDict = {
     "defer_build": True,
     "populate_by_name": True,
-    "validate_assignment": False,
+    "validate_assignment": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.9.2,<4.0
-pydantic>=2.4,<3.0
+pydantic>=2.6,<3.0
 python-dateutil>=2
 typing-extensions>=4,<5.0
 urllib3>=2.1,<3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def parse_requirements(filename: str):
 if __name__ == "__main__":
     setup(
         name=PACKAGE_NAME,
-        version="0.11.0-rev1",
+        version="0.11.0-rev2",
         description="A simple python client for controlling an ACA-Py agent",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
and pin pydantic >2.6 as it solves the memory leak issue previously caused by this config

See: https://github.com/pydantic/pydantic/issues/8239. Issue solved in pydantic-core 2.15. And Pydantic 2.6 bumped pydantic-core from 2.14 to 2.16