### PR TITLE
:sparkles: re-add validate_call to API methods

### DIFF
--- a/aries_cloudcontroller/api/action_menu_api.py
+++ b/aries_cloudcontroller/api/action_menu_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -46,6 +46,7 @@ class ActionMenuApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def close_active_menu(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -272,6 +273,7 @@ class ActionMenuApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def fetch_active_menu(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -498,6 +500,7 @@ class ActionMenuApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def perform_action(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -749,6 +752,7 @@ class ActionMenuApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def request_active_menu(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -975,6 +979,7 @@ class ActionMenuApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_menu(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],

--- a/aries_cloudcontroller/api/basicmessage_api.py
+++ b/aries_cloudcontroller/api/basicmessage_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -44,6 +44,7 @@ class BasicmessageApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def send_message(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],

--- a/aries_cloudcontroller/api/connection_api.py
+++ b/aries_cloudcontroller/api/connection_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -61,6 +61,7 @@ class ConnectionApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def accept_invitation(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -359,6 +360,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def accept_request(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -610,6 +612,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def create_invitation(
         self,
         alias: Annotated[Optional[StrictStr], Field(description="Alias")] = None,
@@ -937,6 +940,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def create_static_connection(
         self,
         body: Optional[ConnectionStaticRequest] = None,
@@ -1179,6 +1183,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_connection(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -1405,6 +1410,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_connection(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -1631,6 +1637,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_connection_endpoint(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -1857,6 +1864,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_connections(
         self,
         alias: Annotated[Optional[StrictStr], Field(description="Alias")] = None,
@@ -2272,6 +2280,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_metadata(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -2520,6 +2529,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def receive_invitation(
         self,
         alias: Annotated[Optional[StrictStr], Field(description="Alias")] = None,
@@ -2822,6 +2832,7 @@ class ConnectionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_metadata(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],

--- a/aries_cloudcontroller/api/credential_definition_api.py
+++ b/aries_cloudcontroller/api/credential_definition_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -55,6 +55,7 @@ class CredentialDefinitionApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def credential_definitions_cred_def_id_write_record_post(
         self,
         cred_def_id: Annotated[
@@ -293,6 +294,7 @@ class CredentialDefinitionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_created_cred_defs(
         self,
         cred_def_id: Annotated[
@@ -657,6 +659,7 @@ class CredentialDefinitionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_cred_def(
         self,
         cred_def_id: Annotated[
@@ -895,6 +898,7 @@ class CredentialDefinitionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def publish_cred_def(
         self,
         conn_id: Annotated[

--- a/aries_cloudcontroller/api/credentials_api.py
+++ b/aries_cloudcontroller/api/credentials_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -54,6 +54,7 @@ class CredentialsApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def delete_record(
         self,
         credential_id: Annotated[StrictStr, Field(description="Credential identifier")],
@@ -280,6 +281,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_w3c_credential(
         self,
         credential_id: Annotated[StrictStr, Field(description="Credential identifier")],
@@ -506,6 +508,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_credential_mime_types(
         self,
         credential_id: Annotated[StrictStr, Field(description="Credential identifier")],
@@ -738,6 +741,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_record(
         self,
         credential_id: Annotated[StrictStr, Field(description="Credential identifier")],
@@ -964,6 +968,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         count: Annotated[
@@ -1250,6 +1255,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_revocation_status(
         self,
         credential_id: Annotated[StrictStr, Field(description="Credential identifier")],
@@ -1532,6 +1538,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_w3c_credential(
         self,
         credential_id: Annotated[StrictStr, Field(description="Credential identifier")],
@@ -1758,6 +1765,7 @@ class CredentialsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_w3c_credentials(
         self,
         count: Annotated[

--- a/aries_cloudcontroller/api/default_api.py
+++ b/aries_cloudcontroller/api/default_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -38,6 +38,7 @@ class DefaultApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def establish_inbound(
         self,
         _request_timeout: Union[
@@ -244,6 +245,7 @@ class DefaultApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_features(
         self,
         _request_timeout: Union[

--- a/aries_cloudcontroller/api/did_exchange_api.py
+++ b/aries_cloudcontroller/api/did_exchange_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -46,6 +46,7 @@ class DidExchangeApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def accept_invitation(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -319,6 +320,7 @@ class DidExchangeApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def accept_request(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -620,6 +622,7 @@ class DidExchangeApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def create_request(
         self,
         their_public_did: Annotated[
@@ -1046,6 +1049,7 @@ class DidExchangeApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def didexchange_conn_id_reject_post(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -1297,6 +1301,7 @@ class DidExchangeApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def receive_request(
         self,
         alias: Annotated[

--- a/aries_cloudcontroller/api/discover_features_api.py
+++ b/aries_cloudcontroller/api/discover_features_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -47,6 +47,7 @@ class DiscoverFeaturesApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def discover_features_query_get(
         self,
         comment: Annotated[Optional[StrictStr], Field(description="Comment")] = None,
@@ -327,6 +328,7 @@ class DiscoverFeaturesApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def discover_features_records_get(
         self,
         connection_id: Annotated[

--- a/aries_cloudcontroller/api/discover_features_v20_api.py
+++ b/aries_cloudcontroller/api/discover_features_v20_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -49,6 +49,7 @@ class DiscoverFeaturesV20Api:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def discover_features20_queries_get(
         self,
         connection_id: Annotated[
@@ -341,6 +342,7 @@ class DiscoverFeaturesV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def discover_features20_records_get(
         self,
         connection_id: Annotated[

--- a/aries_cloudcontroller/api/endorse_transaction_api.py
+++ b/aries_cloudcontroller/api/endorse_transaction_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -48,6 +48,7 @@ class EndorseTransactionApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def cancel_transaction(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],
@@ -274,6 +275,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def create_request(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],
@@ -551,6 +553,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def endorse_transaction(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],
@@ -799,6 +802,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         _request_timeout: Union[
@@ -1010,6 +1014,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_transaction(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],
@@ -1236,6 +1241,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def refuse_transaction(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],
@@ -1462,6 +1468,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def resend_transaction_request(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],
@@ -1688,6 +1695,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_endorser_info(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -1952,6 +1960,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_endorser_role(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -2200,6 +2209,7 @@ class EndorseTransactionApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def write_transaction(
         self,
         tran_id: Annotated[StrictStr, Field(description="Transaction identifier")],

--- a/aries_cloudcontroller/api/introduction_api.py
+++ b/aries_cloudcontroller/api/introduction_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -43,6 +43,7 @@ class IntroductionApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def start_introduction(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],

--- a/aries_cloudcontroller/api/issue_credential_v10_api.py
+++ b/aries_cloudcontroller/api/issue_credential_v10_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -75,6 +75,7 @@ class IssueCredentialV10Api:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_credential(
         self,
         body: Optional[V10CredentialCreate] = None,
@@ -311,6 +312,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def create_offer(
         self,
         body: Optional[V10CredentialConnFreeOfferRequest] = None,
@@ -547,6 +549,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_record(
         self,
         cred_ex_id: Annotated[
@@ -779,6 +782,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_record(
         self,
         cred_ex_id: Annotated[
@@ -1011,6 +1015,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         connection_id: Annotated[
@@ -1319,6 +1324,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def issue_credential(
         self,
         cred_ex_id: Annotated[
@@ -1576,6 +1582,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def issue_credential_automated(
         self,
         body: Optional[V10CredentialProposalRequestMand] = None,
@@ -1812,6 +1819,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def report_problem(
         self,
         cred_ex_id: Annotated[
@@ -2069,6 +2077,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_offer(
         self,
         cred_ex_id: Annotated[
@@ -2326,6 +2335,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_offer_free(
         self,
         body: Optional[V10CredentialFreeOfferRequest] = None,
@@ -2562,6 +2572,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_proposal(
         self,
         body: Optional[V10CredentialProposalRequestOpt] = None,
@@ -2798,6 +2809,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request(
         self,
         cred_ex_id: Annotated[
@@ -3055,6 +3067,7 @@ class IssueCredentialV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def store_credential(
         self,
         cred_ex_id: Annotated[

--- a/aries_cloudcontroller/api/issue_credential_v20_api.py
+++ b/aries_cloudcontroller/api/issue_credential_v20_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -66,6 +66,7 @@ class IssueCredentialV20Api:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_credential(
         self,
         body: Optional[V20IssueCredSchemaCore] = None,
@@ -302,6 +303,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_record(
         self,
         cred_ex_id: Annotated[
@@ -534,6 +536,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_record(
         self,
         cred_ex_id: Annotated[
@@ -766,6 +769,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         connection_id: Annotated[
@@ -1074,6 +1078,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def issue_credential(
         self,
         cred_ex_id: Annotated[
@@ -1331,6 +1336,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def issue_credential20_create_offer_post(
         self,
         body: Optional[V20CredOfferConnFreeRequest] = None,
@@ -1567,6 +1573,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def issue_credential_automated(
         self,
         body: Optional[V20CredExFree] = None,
@@ -1803,6 +1810,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def report_problem(
         self,
         cred_ex_id: Annotated[
@@ -2060,6 +2068,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_offer(
         self,
         cred_ex_id: Annotated[
@@ -2317,6 +2326,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_offer_free(
         self,
         body: Optional[V20CredOfferRequest] = None,
@@ -2553,6 +2563,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_proposal(
         self,
         body: Optional[V20CredExFree] = None,
@@ -2789,6 +2800,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request(
         self,
         cred_ex_id: Annotated[
@@ -3046,6 +3058,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request_free(
         self,
         body: Optional[V20CredRequestFree] = None,
@@ -3282,6 +3295,7 @@ class IssueCredentialV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def store_credential(
         self,
         cred_ex_id: Annotated[

--- a/aries_cloudcontroller/api/jsonld_api.py
+++ b/aries_cloudcontroller/api/jsonld_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -44,6 +44,7 @@ class JsonldApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def sign(
         self,
         body: Optional[SignRequest] = None,
@@ -280,6 +281,7 @@ class JsonldApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def verify(
         self,
         body: Optional[VerifyRequest] = None,

--- a/aries_cloudcontroller/api/ledger_api.py
+++ b/aries_cloudcontroller/api/ledger_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -58,6 +58,7 @@ class LedgerApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def accept_taa(
         self,
         body: Optional[TAAAccept] = None,
@@ -294,6 +295,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def fetch_taa(
         self,
         _request_timeout: Union[
@@ -505,6 +507,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_did_endpoint(
         self,
         did: Annotated[str, Field(strict=True, description="DID of interest")],
@@ -763,6 +766,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_did_nym_role(
         self,
         did: Annotated[str, Field(strict=True, description="DID of interest")],
@@ -990,6 +994,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_did_verkey(
         self,
         did: Annotated[str, Field(strict=True, description="DID of interest")],
@@ -1217,6 +1222,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def ledger_config_get(
         self,
         _request_timeout: Union[
@@ -1428,6 +1434,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def ledger_get_write_ledger_get(
         self,
         _request_timeout: Union[
@@ -1639,6 +1646,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def ledger_get_write_ledgers_get(
         self,
         _request_timeout: Union[
@@ -1856,6 +1864,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def ledger_ledger_id_set_write_ledger_put(
         self,
         ledger_id: StrictStr,
@@ -2082,6 +2091,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def register_nym(
         self,
         did: Annotated[str, Field(strict=True, description="DID to register")],
@@ -2412,6 +2422,7 @@ class LedgerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def rotate_public_did_keypair(
         self,
         _request_timeout: Union[

--- a/aries_cloudcontroller/api/mediation_api.py
+++ b/aries_cloudcontroller/api/mediation_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -55,6 +55,7 @@ class MediationApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def clear_default_mediator(
         self,
         _request_timeout: Union[
@@ -266,6 +267,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_record(
         self,
         mediation_id: Annotated[
@@ -498,6 +500,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def deny_mediation_request(
         self,
         mediation_id: Annotated[
@@ -755,6 +758,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_default_mediator(
         self,
         _request_timeout: Union[
@@ -966,6 +970,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_record(
         self,
         mediation_id: Annotated[
@@ -1198,6 +1203,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         conn_id: Annotated[
@@ -1453,6 +1459,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def grant_mediation_request(
         self,
         mediation_id: Annotated[
@@ -1685,6 +1692,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def mediation_update_keylist_conn_id_post(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -1936,6 +1944,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def request_mediation(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],
@@ -2187,6 +2196,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def retrieve_keylists(
         self,
         conn_id: Annotated[
@@ -2451,6 +2461,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_keylist_query(
         self,
         mediation_id: Annotated[
@@ -2752,6 +2763,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_keylist_update(
         self,
         mediation_id: Annotated[
@@ -3009,6 +3021,7 @@ class MediationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_default_mediator(
         self,
         mediation_id: Annotated[

--- a/aries_cloudcontroller/api/multitenancy_api.py
+++ b/aries_cloudcontroller/api/multitenancy_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -56,6 +56,7 @@ class MultitenancyApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_wallet(
         self,
         body: Optional[CreateWalletRequest] = None,
@@ -292,6 +293,7 @@ class MultitenancyApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_wallet(
         self,
         wallet_id: Annotated[StrictStr, Field(description="Subwallet identifier")],
@@ -543,6 +545,7 @@ class MultitenancyApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_auth_token(
         self,
         wallet_id: StrictStr,
@@ -800,6 +803,7 @@ class MultitenancyApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_wallet(
         self,
         wallet_id: Annotated[StrictStr, Field(description="Subwallet identifier")],
@@ -1026,6 +1030,7 @@ class MultitenancyApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_wallets(
         self,
         wallet_name: Annotated[
@@ -1259,6 +1264,7 @@ class MultitenancyApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_wallets(
         self,
         wallet_name: Annotated[
@@ -1517,6 +1523,7 @@ class MultitenancyApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def update_wallet(
         self,
         wallet_id: Annotated[StrictStr, Field(description="Subwallet identifier")],

--- a/aries_cloudcontroller/api/out_of_band_api.py
+++ b/aries_cloudcontroller/api/out_of_band_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -49,6 +49,7 @@ class OutOfBandApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_invitation(
         self,
         auto_accept: Annotated[
@@ -335,6 +336,7 @@ class OutOfBandApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def receive_invitation(
         self,
         alias: Annotated[

--- a/aries_cloudcontroller/api/present_proof_v10_api.py
+++ b/aries_cloudcontroller/api/present_proof_v10_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -68,6 +68,7 @@ class PresentProofV10Api:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_proof_request(
         self,
         body: Optional[V10PresentationCreateRequestRequest] = None,
@@ -310,6 +311,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_record(
         self,
         pres_ex_id: Annotated[
@@ -542,6 +544,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_matching_credentials(
         self,
         pres_ex_id: Annotated[
@@ -874,6 +877,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_record(
         self,
         pres_ex_id: Annotated[
@@ -1112,6 +1116,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         connection_id: Annotated[
@@ -1420,6 +1425,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def report_problem(
         self,
         pres_ex_id: Annotated[
@@ -1677,6 +1683,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_presentation(
         self,
         pres_ex_id: Annotated[
@@ -1940,6 +1947,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_proposal(
         self,
         body: Optional[V10PresentationProposalRequest] = None,
@@ -2182,6 +2190,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request(
         self,
         pres_ex_id: Annotated[
@@ -2445,6 +2454,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request_free(
         self,
         body: Optional[V10PresentationSendRequestRequest] = None,
@@ -2687,6 +2697,7 @@ class PresentProofV10Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def verify_presentation(
         self,
         pres_ex_id: Annotated[

--- a/aries_cloudcontroller/api/present_proof_v20_api.py
+++ b/aries_cloudcontroller/api/present_proof_v20_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -64,6 +64,7 @@ class PresentProofV20Api:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_proof_request(
         self,
         body: Optional[V20PresCreateRequestRequest] = None,
@@ -300,6 +301,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def delete_record(
         self,
         pres_ex_id: Annotated[
@@ -532,6 +534,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_matching_credentials(
         self,
         pres_ex_id: Annotated[
@@ -864,6 +867,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_record(
         self,
         pres_ex_id: Annotated[
@@ -1096,6 +1100,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_records(
         self,
         connection_id: Annotated[
@@ -1398,6 +1403,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def report_problem(
         self,
         pres_ex_id: Annotated[
@@ -1655,6 +1661,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_presentation(
         self,
         pres_ex_id: Annotated[
@@ -1912,6 +1919,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_proposal(
         self,
         body: Optional[V20PresProposalRequest] = None,
@@ -2148,6 +2156,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request(
         self,
         pres_ex_id: Annotated[
@@ -2405,6 +2414,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def send_request_free(
         self,
         body: Optional[V20PresSendRequestRequest] = None,
@@ -2641,6 +2651,7 @@ class PresentProofV20Api:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def verify_presentation(
         self,
         pres_ex_id: Annotated[

--- a/aries_cloudcontroller/api/resolver_api.py
+++ b/aries_cloudcontroller/api/resolver_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -42,6 +42,7 @@ class ResolverApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def get_did(
         self,
         did: Annotated[str, Field(strict=True, description="DID")],

--- a/aries_cloudcontroller/api/revocation_api.py
+++ b/aries_cloudcontroller/api/revocation_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -70,6 +70,7 @@ class RevocationApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def clear_pending_revocations(
         self,
         body: Optional[ClearPendingRevocationsRequest] = None,
@@ -306,6 +307,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def create_registry(
         self,
         body: Optional[RevRegCreateRequest] = None,
@@ -542,6 +544,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def download_tails_file(
         self,
         rev_reg_id: Annotated[
@@ -774,6 +777,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_active_registry_for_cred_def(
         self,
         cred_def_id: Annotated[
@@ -1006,6 +1010,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_created_registries(
         self,
         cred_def_id: Annotated[
@@ -1264,6 +1269,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_registry(
         self,
         rev_reg_id: Annotated[
@@ -1496,6 +1502,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_registry_issued_credentials_count(
         self,
         rev_reg_id: Annotated[
@@ -1728,6 +1735,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_revocation_status(
         self,
         cred_ex_id: Annotated[
@@ -2014,6 +2022,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def publish_rev_reg_def(
         self,
         rev_reg_id: Annotated[
@@ -2295,6 +2304,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def publish_rev_reg_entry(
         self,
         rev_reg_id: Annotated[
@@ -2576,6 +2586,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def publish_revocations(
         self,
         body: Optional[PublishRevocations] = None,
@@ -2818,6 +2829,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def revocation_active_registry_cred_def_id_rotate_post(
         self,
         cred_def_id: Annotated[
@@ -3050,6 +3062,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def revocation_registry_delete_tails_file_delete(
         self,
         cred_def_id: Annotated[
@@ -3311,6 +3324,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def revocation_registry_rev_reg_id_fix_revocation_entry_state_put(
         self,
         rev_reg_id: Annotated[
@@ -3574,6 +3588,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def revocation_registry_rev_reg_id_issued_details_get(
         self,
         rev_reg_id: Annotated[
@@ -3812,6 +3827,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def revocation_registry_rev_reg_id_issued_indy_recs_get(
         self,
         rev_reg_id: Annotated[
@@ -4050,6 +4066,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def revoke_credential(
         self,
         body: Optional[RevokeRequest] = None,
@@ -4286,6 +4303,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_registry_state(
         self,
         rev_reg_id: Annotated[
@@ -4540,6 +4558,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def update_registry(
         self,
         rev_reg_id: Annotated[
@@ -4797,6 +4816,7 @@ class RevocationApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def upload_tails_file(
         self,
         rev_reg_id: Annotated[

--- a/aries_cloudcontroller/api/schema_api.py
+++ b/aries_cloudcontroller/api/schema_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -47,6 +47,7 @@ class SchemaApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def get_created_schemas(
         self,
         schema_id: Annotated[
@@ -355,6 +356,7 @@ class SchemaApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_schema(
         self,
         schema_id: Annotated[str, Field(strict=True, description="Schema identifier")],
@@ -581,6 +583,7 @@ class SchemaApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def publish_schema(
         self,
         conn_id: Annotated[
@@ -866,6 +869,7 @@ class SchemaApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def write_record(
         self,
         schema_id: Annotated[str, Field(strict=True, description="Schema identifier")],

--- a/aries_cloudcontroller/api/server_api.py
+++ b/aries_cloudcontroller/api/server_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -45,6 +45,7 @@ class ServerApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def check_liveliness(
         self,
         _request_timeout: Union[
@@ -256,6 +257,7 @@ class ServerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_config(
         self,
         _request_timeout: Union[
@@ -467,6 +469,7 @@ class ServerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_plugins(
         self,
         _request_timeout: Union[
@@ -678,6 +681,7 @@ class ServerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_ready_state(
         self,
         _request_timeout: Union[
@@ -889,6 +893,7 @@ class ServerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_status(
         self,
         _request_timeout: Union[
@@ -1100,6 +1105,7 @@ class ServerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def reset_statistics(
         self,
         _request_timeout: Union[
@@ -1311,6 +1317,7 @@ class ServerApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def shutdown_server(
         self,
         _request_timeout: Union[

--- a/aries_cloudcontroller/api/settings_api.py
+++ b/aries_cloudcontroller/api/settings_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -42,6 +42,7 @@ class SettingsApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def settings_get(
         self,
         _request_timeout: Union[
@@ -253,6 +254,7 @@ class SettingsApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def settings_put(
         self,
         body: Optional[UpdateProfileSettings] = None,

--- a/aries_cloudcontroller/api/trustping_api.py
+++ b/aries_cloudcontroller/api/trustping_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -45,6 +45,7 @@ class TrustpingApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def send_ping(
         self,
         conn_id: Annotated[StrictStr, Field(description="Connection identifier")],

--- a/aries_cloudcontroller/api/wallet_api.py
+++ b/aries_cloudcontroller/api/wallet_api.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import Field, StrictFloat, StrictInt, StrictStr, validate_call
 
 try:
     from typing import Annotated
@@ -54,6 +54,7 @@ class WalletApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @validate_call
     async def create_did(
         self,
         body: Optional[DIDCreate] = None,
@@ -290,6 +291,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_did_endpoint(
         self,
         did: Annotated[str, Field(strict=True, description="DID of interest")],
@@ -517,6 +519,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_dids(
         self,
         did: Annotated[
@@ -862,6 +865,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def get_public_did(
         self,
         _request_timeout: Union[
@@ -1073,6 +1077,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def rotate_keypair(
         self,
         did: Annotated[str, Field(strict=True, description="DID of interest")],
@@ -1300,6 +1305,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_did_endpoint(
         self,
         conn_id: Annotated[
@@ -1585,6 +1591,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def set_public_did(
         self,
         did: Annotated[str, Field(strict=True, description="DID of interest")],
@@ -1883,6 +1890,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def wallet_jwt_sign_post(
         self,
         body: Optional[JWSCreate] = None,
@@ -2119,6 +2127,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def wallet_jwt_verify_post(
         self,
         body: Optional[JWSVerify] = None,
@@ -2355,6 +2364,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def wallet_sd_jwt_sign_post(
         self,
         body: Optional[SDJWSCreate] = None,
@@ -2591,6 +2601,7 @@ class WalletApi:
             _request_auth=_request_auth,
         )
 
+    @validate_call
     async def wallet_sd_jwt_verify_post(
         self,
         body: Optional[SDJWSVerify] = None,

--- a/generator/scripts/postprocess-client.sh
+++ b/generator/scripts/postprocess-client.sh
@@ -59,9 +59,6 @@ sed -i 's/doc: SignedDoc/doc: Dict[str, Any]/' aries_cloudcontroller/models/veri
 # Remove block of code associated with this previous change:
 sed -i '/# override the default output from pydantic by calling `to_dict()` of doc/,/self.doc.to_dict()/d' aries_cloudcontroller/models/verify_request.py
 
-# Remove @validate_call decorator to avoid memory leak issue from pydantic
-sed -i '/@validate_call/d' aries_cloudcontroller/api/*.py
-
 # NB:
 # There are 3 more models, and 1 API Module, that we are not amending automatically. These should be reviewed manually:
 # - MultitenancyAPI has custom method to handle our groups plugin!

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def parse_requirements(filename: str):
 if __name__ == "__main__":
     setup(
         name=PACKAGE_NAME,
-        version="0.11.0-rev2",
+        version="0.11.0-rev3",
         description="A simple python client for controlling an ACA-Py agent",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
This re-adds the `validate_call` decorator to API methods, which was previously removed to work around a memory leak issue in Pydantic < 2.6